### PR TITLE
Add one click Docker deployment

### DIFF
--- a/docker-oneclick/.env
+++ b/docker-oneclick/.env
@@ -1,0 +1,23 @@
+TIMEZONE=UTC
+
+# Postgres
+POSTGRES_HOST=teable-db
+POSTGRES_PORT=5432
+POSTGRES_DB=teable
+POSTGRES_USER=teable
+POSTGRES_PASSWORD=123456
+
+# App
+PUBLIC_ORIGIN=http://127.0.0.1:3000
+PRISMA_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+PUBLIC_DATABASE_PROXY=127.0.0.1:42345
+
+# Need to support sending emails to enable the following configurations
+# You need to modify the configuration according to the actual situation, otherwise it will not be able to send emails correctly.
+#BACKEND_MAIL_HOST=smtp.teable.io
+#BACKEND_MAIL_PORT=465
+#BACKEND_MAIL_SECURE=true
+#BACKEND_MAIL_SENDER=noreply.teable.io
+#BACKEND_MAIL_SENDER_NAME=Teable
+BACKEND_MAIL_AUTH_USER=123456
+BACKEND_MAIL_AUTH_PASS=123456

--- a/docker-oneclick/README.md
+++ b/docker-oneclick/README.md
@@ -1,0 +1,13 @@
+# One Click Docker Deployment
+
+This directory contains a simple setup for running **Teable** with Docker.
+
+## Quick Start
+
+```sh
+./deploy.sh
+```
+
+The script uses `docker compose` to start Teable and a Postgres database.
+All passwords are set to `123456` in the provided `.env` file.
+

--- a/docker-oneclick/deploy.sh
+++ b/docker-oneclick/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+SCRIPT_DIR="$(dirname "$0")"
+docker compose -f "$SCRIPT_DIR/docker-compose.yaml" --env-file "$SCRIPT_DIR/.env" up -d
+

--- a/docker-oneclick/docker-compose.yaml
+++ b/docker-oneclick/docker-compose.yaml
@@ -1,0 +1,55 @@
+version: '3.9'
+
+services:
+  teable:
+    image: ghcr.io/teableio/teable:latest
+    restart: always
+    ports:
+      - '3000:3000'
+    volumes:
+      - teable-data:/app/.assets:rw
+      # you may use a bind-mounted host directory instead,
+      # so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./docker/teable/data:/app/.assets:rw
+    env_file:
+      - .env
+    environment:
+      - TZ=${TIMEZONE}
+      - NEXT_ENV_IMAGES_ALL_REMOTE=true
+    networks:
+      - teable-standalone
+    depends_on:
+      teable-db:
+        condition: service_healthy
+
+  teable-db:
+    image: postgres:15.4
+    restart: always
+    ports:
+      - '42345:5432'
+    volumes:
+      - teable-db:/var/lib/postgresql/data:rw
+      # you may use a bind-mounted host directory instead,
+      # so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./docker/db/data:/var/lib/postgresql/data:rw
+    environment:
+      - TZ=${TIMEZONE}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    networks:
+      - teable-standalone
+    healthcheck:
+      test: ['CMD-SHELL', "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+networks:
+  teable-standalone:
+    name: teable-standalone-network
+    driver: bridge
+
+volumes:
+  teable-data: {}
+  teable-db: {}


### PR DESCRIPTION
## Summary
- add docker-oneclick folder with compose file
- include env file with default password `123456`
- add deploy.sh helper and README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68597bf292b8832daa516d8808d053cf