### PR TITLE
Fix missing deploy script

### DIFF
--- a/docker-oneclick/deploy.sh
+++ b/docker-oneclick/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+SCRIPT_DIR="$(dirname "$0")"
+docker compose -f "$SCRIPT_DIR/docker-compose.yaml" --env-file "$SCRIPT_DIR/.env" up -d


### PR DESCRIPTION
## Summary
- restore `docker-oneclick/deploy.sh`

## Testing
- `pnpm g:lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685a28cf3934832daf6965180b1283f2