### PR TITLE
Fix compose warning

### DIFF
--- a/docker-oneclick/docker-compose.yaml
+++ b/docker-oneclick/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   teable:
     image: ghcr.io/teableio/teable:latest


### PR DESCRIPTION
## Summary
- remove deprecated `version` key from docker-oneclick compose file

## Testing
- `pnpm run g:lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a41ec01f8832dbf5a6fe76665e8bb