### PR TITLE
Explain PUBLIC_ORIGIN for remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ More features coming soon, see our <a target="_blank" href="https://app.teable.i
 ./deploy.sh
 ```
 
+Edit `docker-oneclick/.env` before running if the instance should be reachable
+from other machines. Change `PUBLIC_ORIGIN` to your server's domain or IP
+(for example `http://your-server-ip:3000`).
+
 This script starts Teable and a Postgres instance using Docker Compose. All passwords are preset to `123456`.
 
 ```sh

--- a/docker-oneclick/.env
+++ b/docker-oneclick/.env
@@ -8,7 +8,9 @@ POSTGRES_USER=example
 POSTGRES_PASSWORD=123456
 
 # App
-PUBLIC_ORIGIN=http://127.0.0.1:3000
+# Change PUBLIC_ORIGIN to your server's domain or IP if you need to access
+# Teable from another machine.
+PUBLIC_ORIGIN=http://localhost:3000
 PRISMA_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 PUBLIC_DATABASE_PROXY=127.0.0.1:42345
 


### PR DESCRIPTION
## Summary
- document how to edit PUBLIC_ORIGIN so Teable can be reached from other machines
- clarify PUBLIC_ORIGIN setting in `docker-oneclick/.env`

## Testing
- `pnpm g:lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685a479c2ca8832d978d9be01f7fc005